### PR TITLE
Added backticks to device id dialing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following **environment variables** are used:
 - `GOOGLE_LOGIN` - email address used on a mobile phone.
 - `GOOGLE_PASSWORD` - The password used to access the Play service.
 - `ANDROID_ID` - the ID for the device for Google. Your ID can be obtained by
-  "dialing" *#*#8255#*#* - look for Device ID, remove `android-` prefix.
+  "dialing" `*#*#8255#*#*` - look for Device ID, remove `android-` prefix.
 
 # USAGE
 


### PR DESCRIPTION
From the current README, it looks like the number you need to dial is `##8255##` instead of `*#*#8255#*#*` because markdown parses it that way. Fixed it by adding backticks around it.
